### PR TITLE
Force use for qtubuntu-sensors

### DIFF
--- a/src/platforms/mirserver/screen.cpp
+++ b/src/platforms/mirserver/screen.cpp
@@ -152,6 +152,11 @@ Screen::Screen(const mir::graphics::DisplayConfigurationOutput &screen)
 {
     setMirDisplayConfiguration(screen, false);
 
+    qCDebug(QTMIR_SENSOR_MESSAGES) << "Screen - identifier is:" << m_orientationSensor->identifier();
+
+    // FIXME: Forcing use of qtubuntu-sensors!
+    m_orientationSensor->setIdentifier("core.orientation");
+
     // Set the default orientation based on the initial screen dimmensions.
     m_nativeOrientation = (m_geometry.width() >= m_geometry.height())
         ? Qt::LandscapeOrientation : Qt::PortraitOrientation;


### PR DESCRIPTION
For now this is a working solution, but later on we need to look into why /etc/xdg/QtProject/Sensors.conf is ignored. Looking at strace it does get loaded, but i have no clue why it does not use it!