### PR TITLE
Provide corrected implementation of mir 0.31.0 compatibility

### DIFF
--- a/src/platforms/mirserver/surfaceobserver.h
+++ b/src/platforms/mirserver/surfaceobserver.h
@@ -23,6 +23,7 @@
 
 #include <mir_toolkit/common.h>
 #include <mir/geometry/size.h>
+#include <mir/version.h>
 
 namespace mir {
     namespace scene {
@@ -39,7 +40,11 @@ class SurfaceObserver : public QObject
 public:
     virtual ~SurfaceObserver();
 
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 31, 0)
+    virtual void frame_posted(mir::scene::Surface const*, int frames_available, mir::geometry::Size const& size ) = 0;
+#else
     virtual void frame_posted(int frames_available, mir::geometry::Size const& size ) = 0;
+#endif
 
     void notifySurfaceModifications(const miral::WindowSpecification&);
 

--- a/tests/modules/WindowManager/mirsurface_test.cpp
+++ b/tests/modules/WindowManager/mirsurface_test.cpp
@@ -47,6 +47,7 @@ struct MirEvent {}; // otherwise won't compile otherwise due to incomplete type
 
 // mir
 #include <mir/scene/surface_creation_parameters.h>
+#include <mir/version.h>
 
 // miral
 #include <miral/window.h>
@@ -103,7 +104,11 @@ TEST_F(MirSurfaceTest, UpdateTextureBeforeDraw)
         .WillRepeatedly(Return(std::make_shared<mir::graphics::StubBuffer>()));
 
     MirSurface surface(mockWindowInfo, nullptr);
+#if MIR_SERVER_VERSION >= MIR_VERSION_NUMBER(0, 31, 0)
+    surface.surfaceObserver()->frame_posted(NULL, 1, mir::geometry::Size{1,1});
+#else
     surface.surfaceObserver()->frame_posted(1, mir::geometry::Size{1,1});
+#endif
 
     QSignalSpy spyFrameDropped(&surface, SIGNAL(frameDropped()));
     QTest::qWait(300);


### PR DESCRIPTION
This PR fixes the compatibility layer for more recent mir versions, with the dependency on mir 0.30.0 being replaced by the correct 0.31.0.  In addition to the essential fix, this new implementation separates out the conditions a bit better to avoid code duplication and nested `#if` blocks, and to improve separation of concerns.
    
The compatibility layer has been introduced in a separate patch so as to have a clean implementation in the version history; this patch is then merged on top of the previous attempt.
    
Fixes https://github.com/ubports/qtmir/issues/2.