### PR TITLE
Remove unneccessary moc from class

### DIFF
--- a/src/modules/Unity/Application/mirsurfaceitem.cpp
+++ b/src/modules/Unity/Application/mirsurfaceitem.cpp
@@ -917,5 +917,3 @@ void MirSurfaceItem::setFillMode(FillMode value)
 }
 
 } // namespace qtmir
-
-#include "mirsurfaceitem.moc"


### PR DESCRIPTION
Fixes the following warning:
```
AutoMoc warning
---------------
  "/home/pmos/build/src/qtmir-7ba43e5310f39219ee01e73976d44e4b581fc4df/src/modules/Unity/Application/mirsurfaceitem.cpp"
The file includes the moc file "mirsurfaceitem.moc", but does not contain a Q_OBJECT, Q_GADGET or Q_NAMESPACE macro.
```