### PR TITLE
Move and Orientation impl out of screen and into it's own improved class

### DIFF
--- a/src/platforms/mirserver/CMakeLists.txt
+++ b/src/platforms/mirserver/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(qpa-mirserver SHARED
     ubuntutheme.cpp
     windowcontroller.cpp
     windowmanagementpolicy.cpp
+    orientationsensor.cpp
 
     ${CMAKE_SOURCE_DIR}/src/common/debughelpers.cpp
     ${CMAKE_SOURCE_DIR}/src/common/timestamp.cpp

--- a/src/platforms/mirserver/orientationsensor.cpp
+++ b/src/platforms/mirserver/orientationsensor.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2019 UBports
+ * Authors: Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "orientationsensor.h"
+#include "logging.h"
+
+// Qt sensors
+#include <QtSensors/QOrientationReading>
+#include <QtSensors/QOrientationSensor>
+
+// Used by tests
+bool OrientationSensor::skipDBusRegistration = false;
+
+OrientationSensor::OrientationSensor(QObject *parent)
+    : QObject(parent)
+    , m_orientationSensor(nullptr)
+    , m_unityScreen(nullptr)
+    , m_enabled(false)
+    , m_started(false)
+{
+}
+
+void OrientationSensor::onDisplayPowerStateChanged(int status, int /*reason*/)
+{
+    qCDebug(QTMIR_SENSOR_MESSAGES) << "OrientationSensor::onDisplayPowerStateChanged";
+    if (m_orientationSensor != nullptr) {
+        if (status)
+            start();
+        else
+            stop();
+    }
+}
+
+// Used by tests
+bool OrientationSensor::enabled() {
+    if (m_orientationSensor != nullptr)
+        return m_orientationSensor->isActive();
+    return false;
+}
+
+void OrientationSensor::start() {
+    m_started = true;
+    startIfNeeded();
+}
+
+void OrientationSensor::stop() {
+    if (m_orientationSensor != nullptr) {
+        if (m_orientationSensor->isActive())
+            m_orientationSensor->stop();
+    }
+}
+
+void OrientationSensor::enable() {
+    m_enabled = true;
+    startIfNeeded();
+}
+
+// Make sure we dont start/enable the sensor or dbus if it's not needed
+void OrientationSensor::startIfNeeded() {
+    // We need to initiaze the sensor after the main mir thread has started
+    if (m_orientationSensor == nullptr && m_enabled && m_started) {
+        m_orientationSensor = new QOrientationSensor(this);
+        QObject::connect(m_orientationSensor, &QOrientationSensor::readingChanged,
+                        this, [this]() {
+                        qCDebug(QTMIR_SENSOR_MESSAGES) << "OrientationSensor::readingChanged";
+                        Q_EMIT onOrientationChanged(m_orientationSensor->reading()->orientation()); });
+
+        if (!skipDBusRegistration) {
+            // FIXME This is a unity8 specific dbus call and shouldn't be in qtmir
+            m_unityScreen = new QDBusInterface(QStringLiteral("com.canonical.Unity.Screen"),
+                                            QStringLiteral("/com/canonical/Unity/Screen"),
+                                            QStringLiteral("com.canonical.Unity.Screen"),
+                                            QDBusConnection::systemBus(), this);
+
+            m_unityScreen->connection().connect(QStringLiteral("com.canonical.Unity.Screen"),
+                                            QStringLiteral("/com/canonical/Unity/Screen"),
+                                            QStringLiteral("com.canonical.Unity.Screen"),
+                                            QStringLiteral("DisplayPowerStateChange"),
+                                            this,
+                                            SLOT(onDisplayPowerStateChanged(int, int)));
+        }
+    }
+    if (m_orientationSensor != nullptr) {
+        if (!m_orientationSensor->isActive())
+            m_orientationSensor->start();
+    }
+}

--- a/src/platforms/mirserver/orientationsensor.h
+++ b/src/platforms/mirserver/orientationsensor.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 UBports
+ * Authors: Marius Gripsgard <marius@ubports.com>
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+ * SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QtSensors/QOrientationReading>
+#include <QtDBus/QDBusInterface>
+
+class OrientationSensor : public QObject
+{
+     Q_OBJECT
+public:
+    OrientationSensor(QObject *parent = 0);
+
+    void start();
+    void stop();
+    void enable();
+
+    // To make it testable
+    static bool skipDBusRegistration;
+    bool enabled();
+
+Q_SIGNALS:
+    void onOrientationChanged(QOrientationReading::Orientation);
+
+public Q_SLOTS:
+    void onDisplayPowerStateChanged(int, int);
+
+private:
+    void startIfNeeded();
+
+    QOrientationSensor *m_orientationSensor;
+    QDBusInterface *m_unityScreen;
+    bool m_enabled;
+    bool m_started;
+ };

--- a/src/platforms/mirserver/screensmodel.h
+++ b/src/platforms/mirserver/screensmodel.h
@@ -40,7 +40,7 @@ namespace mir {
 
 class Screen;
 class QtCompositor;
-
+class OrientationSensor;
 /*
  * ScreensModel monitors the Mir display configuration and compositor status, and updates
  * the relevant QScreen and QWindow states accordingly.
@@ -103,6 +103,7 @@ private:
     std::shared_ptr<mir::compositor::DisplayListener> m_displayListener;
     QList<Screen*> m_screenList;
     bool m_compositing;
+    std::shared_ptr<OrientationSensor> m_orientationSensor;
 };
 
 #endif // SCREENCONTROLLER_H

--- a/tests/mirserver/Screen/screen_test.cpp
+++ b/tests/mirserver/Screen/screen_test.cpp
@@ -21,6 +21,7 @@
 #include "fake_displayconfigurationoutput.h"
 
 #include <screen.h>
+#include <orientationsensor.h>
 
 #include <QSensorManager>
 
@@ -47,40 +48,44 @@ void ScreenTest::SetUp()
         }
     }
 
-    Screen::skipDBusRegistration = true;
+    OrientationSensor::skipDBusRegistration = true;
 }
 
 TEST_F(ScreenTest, OrientationSensorForExternalDisplay)
 {
-    Screen *screen = new Screen(fakeOutput1); // is external display (dvi)
+    auto orientationSensor = std::make_shared<OrientationSensor>();
+    orientationSensor->start();
+    Screen *screen = new Screen(fakeOutput1, orientationSensor); // is external display (dvi)
 
     // Default state should be disabled
     ASSERT_FALSE(screen->orientationSensorEnabled());
 
-    screen->onDisplayPowerStateChanged(0,0);
-    ASSERT_FALSE(screen->orientationSensorEnabled());
+    orientationSensor->onDisplayPowerStateChanged(0,0);
+    ASSERT_FALSE(orientationSensor->enabled());
 
-    screen->onDisplayPowerStateChanged(1,0);
-    ASSERT_FALSE(screen->orientationSensorEnabled());
+    orientationSensor->onDisplayPowerStateChanged(1,0);
+    ASSERT_FALSE(orientationSensor->enabled());
 }
 
 TEST_F(ScreenTest, OrientationSensorForInternalDisplay)
 {
-    Screen *screen = new Screen(fakeOutput2); // is internal display
+    auto orientationSensor = std::make_shared<OrientationSensor>();
+    orientationSensor->start();
+    Screen *screen = new Screen(fakeOutput2, orientationSensor); // is internal display
 
     // Default state should be active
     ASSERT_TRUE(screen->orientationSensorEnabled());
 
-    screen->onDisplayPowerStateChanged(0,0);
-    ASSERT_FALSE(screen->orientationSensorEnabled());
+    orientationSensor->onDisplayPowerStateChanged(0,0);
+    ASSERT_FALSE(orientationSensor->enabled());
 
-    screen->onDisplayPowerStateChanged(1,0);
-    ASSERT_TRUE(screen->orientationSensorEnabled());
+    orientationSensor->onDisplayPowerStateChanged(1,0);
+    ASSERT_TRUE(orientationSensor->enabled());
 }
 
 TEST_F(ScreenTest, ReadConfigurationFromDisplayConfig)
 {
-    Screen *screen = new Screen(fakeOutput1);
+    Screen *screen = new Screen(fakeOutput1, std::make_shared<OrientationSensor>());
 
     EXPECT_EQ(screen->geometry(), QRect(0, 0, 150, 200));
     EXPECT_EQ(screen->availableGeometry(), QRect(0, 0, 150, 200));
@@ -93,7 +98,7 @@ TEST_F(ScreenTest, ReadConfigurationFromDisplayConfig)
 
 TEST_F(ScreenTest, ReadDifferentConfigurationFromDisplayConfig)
 {
-    Screen *screen = new Screen(fakeOutput2);
+    Screen *screen = new Screen(fakeOutput2, std::make_shared<OrientationSensor>());
 
     EXPECT_EQ(screen->geometry(), QRect(500, 600, 1500, 2000));
     EXPECT_EQ(screen->availableGeometry(), QRect(500, 600, 1500, 2000));

--- a/tests/mirserver/ScreensModel/screensmodel_test.cpp
+++ b/tests/mirserver/ScreensModel/screensmodel_test.cpp
@@ -28,6 +28,7 @@
 #include "testable_screensmodel.h"
 #include "screen.h"
 #include "screenwindow.h"
+#include "orientationsensor.h"
 
 #include <QGuiApplication>
 #include <QLoggingCategory>
@@ -54,7 +55,7 @@ protected:
 void ScreensModelTest::SetUp()
 {
     setenv("QT_QPA_PLATFORM", "minimal", 1);
-    Screen::skipDBusRegistration = true;
+    OrientationSensor::skipDBusRegistration = true;
 
     // We don't want the logging spam cluttering the test results
     QLoggingCategory::setFilterRules(QStringLiteral("qtmir.*=false"));

--- a/tests/mirserver/ScreensModel/stub_screen.h
+++ b/tests/mirserver/ScreensModel/stub_screen.h
@@ -18,12 +18,13 @@
 #define STUBSCREEN_H
 
 #include "screen.h"
+#include "orientationsensor.h"
 
 class StubScreen : public Screen
 {
     Q_OBJECT
 public:
-    StubScreen(const mir::graphics::DisplayConfigurationOutput &output) : Screen(output) {}
+    StubScreen(const mir::graphics::DisplayConfigurationOutput &output) : Screen(output, std::make_shared<OrientationSensor>()) {}
 
     void makeCurrent() { Screen::makeCurrent(); }
 };


### PR DESCRIPTION
This moves the Orientation impl out of the screen impl where it listen for a
QSensor event once insted of on each screen class.

It also makes sure that screen runs on the orientations thread, this is needed
for signals to work.