### PR TITLE
[MirSurface] Make sure we handle resize events while wating on next buffer

### DIFF
--- a/src/modules/Unity/Application/mirsurface.cpp
+++ b/src/modules/Unity/Application/mirsurface.cpp
@@ -332,6 +332,7 @@ void MirSurface::dropPendingBuffer()
             texture->setBuffer(renderables[0]->buffer());
             if (texture->textureSize() != size()) {
                 m_size = texture->textureSize();
+                m_sizePendingChange = false;
                 QMetaObject::invokeMethod(this, "emitSizeChanged", Qt::QueuedConnection);
             }
             m_textureUpdated = true;
@@ -408,6 +409,7 @@ bool MirSurface::updateTexture()
 
         if (texture->textureSize() != size()) {
             m_size = texture->textureSize();
+            m_sizePendingChange = false;
             QMetaObject::invokeMethod(this, "emitSizeChanged", Qt::QueuedConnection);
         }
 
@@ -537,8 +539,9 @@ void MirSurface::resize(int width, int height)
 
     bool mirSizeIsDifferent = width != m_size.width() || height != m_size.height();
 
-    if (mirSizeIsDifferent) {
+    if (mirSizeIsDifferent || m_sizePendingChange) {
         m_controller->resize(m_window, QSize(width, height));
+        m_sizePendingChange = true;
         DEBUG_MSG << " old (" << m_size.width() << "," << m_size.height() << ")"
                   << ", new (" << width << "," << height << ")";
     }

--- a/src/modules/Unity/Application/mirsurface.h
+++ b/src/modules/Unity/Application/mirsurface.h
@@ -262,6 +262,7 @@ private:
     QPoint m_position;
     QPoint m_requestedPosition;
     QSize m_size;
+    bool m_sizePendingChange;
     QSize m_pendingResize;
     QString m_keymap;
 


### PR DESCRIPTION
We need to make sure we handle all resize events that comes in, this
makes sure we send those events even if the next buffer/texture has not
been updated/dropped yet.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1091