### PR TITLE
Implement forceClose method to mirSurface api

### DIFF
--- a/src/modules/Unity/Application/mirsurface.cpp
+++ b/src/modules/Unity/Application/mirsurface.cpp
@@ -530,6 +530,15 @@ void MirSurface::close()
     }
 }
 
+void MirSurface::forceClose()
+{
+    INFO_MSG << "()";
+
+    if (m_window) {
+        m_controller->forceClose(m_window);
+    }
+}
+
 void MirSurface::resize(int width, int height)
 {
     if (!clientIsRunning()) {

--- a/src/modules/Unity/Application/mirsurface.h
+++ b/src/modules/Unity/Application/mirsurface.h
@@ -106,6 +106,7 @@ public:
     unity::shell::application::MirSurfaceListInterface *childSurfaceList() const override;
 
     Q_INVOKABLE void close() override;
+    Q_INVOKABLE void forceClose() override;
 
     ////
     // qtmir::MirSurfaceInterface

--- a/tests/framework/fake_mirsurface.h
+++ b/tests/framework/fake_mirsurface.h
@@ -88,6 +88,7 @@ public:
     void close() override {
         Q_EMIT closeRequested();
     }
+    void forceClose() override {}
 
     void activate() override {}
 


### PR DESCRIPTION
This implements forceClose method to the mirSurface api

Needs https://github.com/ubports/unity-api/pull/14 to be merged & built before this.