### PR TITLE
Revert "Do not forcefully kill and hide apps, let them handle the SIGTERM

### DIFF
--- a/src/modules/Unity/Application/application.h
+++ b/src/modules/Unity/Application/application.h
@@ -65,6 +65,7 @@ public:
         SuspendingWaitSession,
         SuspendingWaitProcess,
         Suspended,
+        Closing, // The user has requested the app be closed
         StoppedResumable, // The process stopped but we want to keep the Application object around
                           // so it can be respawned as if it never stopped running in the first place.
         Stopped // It closed itself, crashed or it stopped and we can't respawn it
@@ -161,7 +162,7 @@ private:
     void applyRequestedSuspended();
     void applyClosing();
     void onSessionStopped();
-    SessionInterface::State combinedSessionState() const;
+    SessionInterface::State combinedSessionState();
 
     QSharedPointer<SharedWakelock> m_sharedWakelock;
     QSharedPointer<ApplicationInfo> m_appInfo;

--- a/src/modules/Unity/Application/application_manager.cpp
+++ b/src/modules/Unity/Application/application_manager.cpp
@@ -390,9 +390,6 @@ bool ApplicationManager::stopApplication(const QString &inputAppId)
     qCDebug(QTMIR_APPLICATIONS) << "ApplicationManager::stopApplication - appId=" << appId;
 
     Application *application = findApplicationMutexHeld(appId);
-    if (!application) { // maybe it's already on the closing list
-        application = findClosingApplication(appId);
-    }
     if (!application) {
         qCritical() << "No such running application with appId" << appId;
         return false;
@@ -405,9 +402,9 @@ bool ApplicationManager::stopApplication(const QString &inputAppId)
 
 void ApplicationManager::onApplicationClosing(Application *application)
 {
-    connect(application, &QObject::destroyed, this, [this, application](QObject*) {
-        m_closingApplications.removeAll(application);
-    });
+    QMutexLocker locker(&m_mutex);
+    remove(application);
+
     m_closingApplications.append(application);
 }
 

--- a/src/modules/Unity/Application/mirsurface.cpp
+++ b/src/modules/Unity/Application/mirsurface.cpp
@@ -18,6 +18,7 @@
 #include "mirsurfacelistmodel.h"
 #include "namedcursor.h"
 #include "session_interface.h"
+#include "timer.h"
 #include "timestamp.h"
 
 // from common dir
@@ -234,6 +235,8 @@ MirSurface::MirSurface(NewWindow newWindowInfo,
 
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 
+    setCloseTimer(new Timer);
+
     m_requestedPosition.rx() = std::numeric_limits<int>::min();
     m_requestedPosition.ry() = std::numeric_limits<int>::min();
 }
@@ -246,6 +249,8 @@ MirSurface::~MirSurface()
 
     QMutexLocker locker(&m_mutex);
     m_surface->remove_observer(m_surfaceObserver);
+
+    delete m_closeTimer;
 
     Q_EMIT destroyed(this); // Early warning, while MirSurface methods can still be accessed.
 }
@@ -523,7 +528,15 @@ void MirSurface::updateVisible()
 
 void MirSurface::close()
 {
+    if (m_closingState != NotClosing) {
+        return;
+    }
+
     INFO_MSG << "()";
+
+    m_closingState = Closing;
+    Q_EMIT closeRequested();
+    m_closeTimer->start();
 
     if (m_window) {
         m_controller->requestClose(m_window);
@@ -1032,6 +1045,38 @@ void MirSurface::activate()
     INFO_MSG << "()";
     if (m_live) {
         m_controller->activate(m_window);
+    }
+}
+
+void MirSurface::onCloseTimedOut()
+{
+    Q_ASSERT(m_closingState == Closing);
+
+    INFO_MSG << "()";
+
+    m_closingState = CloseOverdue;
+
+    if (m_live) {
+        m_controller->forceClose(m_window);
+    }
+}
+
+void MirSurface::setCloseTimer(AbstractTimer *timer)
+{
+    bool timerWasRunning = false;
+
+    if (m_closeTimer) {
+        timerWasRunning = m_closeTimer->isRunning();
+        delete m_closeTimer;
+    }
+
+    m_closeTimer = timer;
+    m_closeTimer->setInterval(3000);
+    m_closeTimer->setSingleShot(true);
+    connect(m_closeTimer, &AbstractTimer::timeout, this, &MirSurface::onCloseTimedOut);
+
+    if (timerWasRunning) {
+        m_closeTimer->start();
     }
 }
 

--- a/src/modules/Unity/Application/mirsurface.h
+++ b/src/modules/Unity/Application/mirsurface.h
@@ -44,6 +44,7 @@ class SurfaceObserver;
 
 namespace qtmir {
 
+class AbstractTimer;
 class MirSurfaceListModel;
 class SessionInterface;
 
@@ -176,6 +177,7 @@ public:
     miral::Window window() const { return m_window; }
 
     // useful for tests
+    void setCloseTimer(AbstractTimer *timer);
     std::shared_ptr<SurfaceObserver> surfaceObserver() const;
 
 public Q_SLOTS:
@@ -194,6 +196,7 @@ private Q_SLOTS:
     void onFramesPostedObserved();
     void emitSizeChanged();
     void setCursor(const QCursor &cursor);
+    void onCloseTimedOut();
     void setInputBounds(const QRect &rect);
 
 private:
@@ -274,6 +277,14 @@ private:
     QRect m_inputBounds;
 
     bool m_focused{false};
+
+    enum ClosingState {
+        NotClosing = 0,
+        Closing = 1,
+        CloseOverdue = 2
+    };
+    ClosingState m_closingState{NotClosing};
+    AbstractTimer *m_closeTimer{nullptr};
 
     // assumes parent won't be destroyed before its children
     MirSurface *m_parentSurface;

--- a/tests/framework/qtmir_test.cpp
+++ b/tests/framework/qtmir_test.cpp
@@ -42,6 +42,9 @@ void PrintTo(const Application::InternalState& state, ::std::ostream* os)
     case Application::InternalState::StoppedResumable:
         *os << "StoppedResumable";
         break;
+    case Application::InternalState::Closing:
+        *os << "Closing";
+        break;
     case Application::InternalState::Stopped:
         *os << "Stopped";
         break;

--- a/tests/modules/ApplicationManager/application_manager_test.cpp
+++ b/tests/modules/ApplicationManager/application_manager_test.cpp
@@ -868,7 +868,7 @@ TEST_F(ApplicationManagerTests,shellStopsForegroundAppCorrectly)
     surface.reset();
 
     // now it's the turn of the application process itself to go away, since its last surface has gone
-    EXPECT_EQ(Application::InternalState::Running, app->internalState());
+    EXPECT_EQ(Application::InternalState::Closing, app->internalState());
 
     // Simulates that the application complied to the close() request and stopped itself
     taskController->onSessionStopping(appInfo);
@@ -1798,9 +1798,9 @@ TEST_F(ApplicationManagerTests,applicationStartQueuedOnStartStopStart)
 
     Mock::VerifyAndClearExpectations(taskController);
 
-//    EXPECT_CALL(*taskController, start(appId, _))
-//        .Times(1)
-//        .WillOnce(Return(true));
+    EXPECT_CALL(*taskController, start(appId, _))
+        .Times(1)
+        .WillOnce(Return(true));
 
     QSignalSpy closeRequestedSpy(surface.data(), SIGNAL(closeRequested()));
 
@@ -1814,7 +1814,7 @@ TEST_F(ApplicationManagerTests,applicationStartQueuedOnStartStopStart)
     surface.reset();
 
     // now it's the turn of the application process itself to go away, since its last surface has gone
-    EXPECT_EQ(Application::InternalState::Running, app->internalState());
+    EXPECT_EQ(Application::InternalState::Closing, app->internalState());
 
     // Trying to start a new instance of this app while we are still waiting for its current
     // instance to end yields no immediate result. This command gets queued instead.
@@ -1830,7 +1830,7 @@ TEST_F(ApplicationManagerTests,applicationStartQueuedOnStartStopStart)
     qtApp.sendPostedEvents(app, QEvent::DeferredDelete);
     qtApp.sendPostedEvents();
 
-    EXPECT_EQ(0, appAddedSpy.count());
+    EXPECT_EQ(1, appAddedSpy.count());
 }
 
 /*


### PR DESCRIPTION
This reverts commit d0a408dd7e36090e038cbbbdab742fe5c188d7a8, reversing
changes made to 0d3683a4610b1c690113f48df7556822cfb8ce94.

This should have never ended up in edge, it comes from https://code.launchpad.net/~lukas-kde/unity8/betterSessionManagement/+merge/316212 and somehow got included when moving to git from bzr. This is WIP and should have never ended up here. 

Fixes: https://github.com/ubports/ubuntu-touch/issues/1111
Fixes: https://github.com/ubports/unity8/issues/131
Fixes: https://github.com/ubports/ubuntu-touch/issues/1103
Fixes: https://github.com/ubports/ubuntu-touch/issues/1177

This fixes lots of issues YAY