### PR TITLE
Dont automaticly switch to newly placed window, let unity8 handle this

### DIFF
--- a/src/platforms/mirserver/windowmanagementpolicy.cpp
+++ b/src/platforms/mirserver/windowmanagementpolicy.cpp
@@ -74,8 +74,6 @@ miral::WindowSpecification WindowManagementPolicy::place_new_window(
 
 void WindowManagementPolicy::handle_window_ready(miral::WindowInfo &windowInfo)
 {
-    CanonicalWindowManagerPolicy::handle_window_ready(windowInfo);
-
     Q_EMIT m_windowModel.windowReady(windowInfo);
 
     auto appInfo = tools.info_for(windowInfo.window().application());


### PR DESCRIPTION
Lets not invoke CanonicalWindowManagerPolicy::handle_window_ready as it will result in the window getting automatically activated regardless if it's placeholder in unity8 is focused or not. We should let unity8 decide when to focus a new window.

Needs: 