### PR TITLE
Send SIGKILL insted of using mir's force_close

### DIFF
--- a/src/modules/Unity/Application/application.cpp
+++ b/src/modules/Unity/Application/application.cpp
@@ -908,6 +908,14 @@ void Application::terminate()
     }
 }
 
+void Application::diemf()
+{
+    for (auto session : m_sessions) {
+        kill(session->pid(), SIGKILL);
+    }
+}
+
+
 QVector<SessionInterface*> Application::sessions() const
 {
     return m_sessions;

--- a/src/modules/Unity/Application/application.h
+++ b/src/modules/Unity/Application/application.h
@@ -127,6 +127,7 @@ public:
     void requestFocus();
 
     void terminate();
+    void diemf();
 
     // for tests
     void setStopTimer(AbstractTimer *timer);

--- a/src/modules/Unity/Application/mirsurface.cpp
+++ b/src/modules/Unity/Application/mirsurface.cpp
@@ -20,6 +20,7 @@
 #include "session_interface.h"
 #include "timer.h"
 #include "timestamp.h"
+#include "application.h"
 
 // from common dir
 #include <debughelpers.h>
@@ -1057,7 +1058,8 @@ void MirSurface::onCloseTimedOut()
     m_closingState = CloseOverdue;
 
     if (m_live) {
-        m_controller->forceClose(m_window);
+        Application *app = static_cast<Application*>(m_session->application());
+        app->diemf();
     }
 }
 


### PR DESCRIPTION
Using forceClose results in mir just removing the surface and not destroying the app as it should. Using sigkill we make sure to destroy the app and not just the surface attached to it.

In some cases we do allow more then one surface, in this case a force_close would be a valid call. but this gets trown out the window as application->ual->upstart tries to terminate the application and making the other surfaces die at some point anyway. 

This fixes: https://github.com/ubports/ubuntu-touch/issues/1184