### PR TITLE
Let applicationManager handle force close of applications

### DIFF
--- a/src/modules/Unity/Application/application.cpp
+++ b/src/modules/Unity/Application/application.cpp
@@ -906,6 +906,14 @@ void Application::terminate()
     for (auto session : m_sessions) {
         kill(session->pid(), SIGTERM);
     }
+
+    // Same as upstart, first sigterm, then sigkill after 5s
+    // Se: https://github.com/ubports/ubuntu-app-launch/blob/9ffa5f76711d600c10c20795cdaeb2c0abfa7cde/libubuntu-app-launch/application-impl-base.cpp#L320
+    QTimer::singleShot(5000, this, [this]() {
+        for (auto session : m_sessions) {
+            kill(session->pid(), SIGKILL);
+        }
+    });
 }
 
 QVector<SessionInterface*> Application::sessions() const

--- a/src/modules/Unity/Application/application.cpp
+++ b/src/modules/Unity/Application/application.cpp
@@ -908,7 +908,7 @@ void Application::terminate()
     }
 
     // Same as upstart, first sigterm, then sigkill after 5s
-    // Se: https://github.com/ubports/ubuntu-app-launch/blob/9ffa5f76711d600c10c20795cdaeb2c0abfa7cde/libubuntu-app-launch/application-impl-base.cpp#L320
+    // See: https://github.com/ubports/ubuntu-app-launch/blob/9ffa5f76711d600c10c20795cdaeb2c0abfa7cde/libubuntu-app-launch/application-impl-base.cpp#L320
     QTimer::singleShot(5000, this, [this]() {
         for (auto session : m_sessions) {
             kill(session->pid(), SIGKILL);

--- a/src/modules/Unity/Application/application.h
+++ b/src/modules/Unity/Application/application.h
@@ -123,11 +123,11 @@ public:
 
     // internal as in "not exposed in unity-api", so qtmir-internal.
     InternalState internalState() const { return m_state; }
+    bool isClosing() const { return m_closing; }
 
     void requestFocus();
 
     void terminate();
-
     // for tests
     void setStopTimer(AbstractTimer *timer);
     AbstractTimer *stopTimer() const { return m_stopTimer; }

--- a/src/modules/Unity/Application/mirsurface.cpp
+++ b/src/modules/Unity/Application/mirsurface.cpp
@@ -20,6 +20,7 @@
 #include "session_interface.h"
 #include "timer.h"
 #include "timestamp.h"
+#include "application.h"
 
 // from common dir
 #include <debughelpers.h>
@@ -1057,6 +1058,16 @@ void MirSurface::onCloseTimedOut()
     m_closingState = CloseOverdue;
 
     if (m_live) {
+        if (m_session && m_session->application()) {
+            Application *app = static_cast<Application*>(m_session->application());
+
+            // If the application is in progress of closing, we let the applicationManager
+            // handle closing of the application.
+            if (app->isClosing()) {
+                return;
+            }
+        }
+
         m_controller->forceClose(m_window);
     }
 }


### PR DESCRIPTION
If application (and just a not surface) is in the progress of closing, we should let applicationManager (and upstart) handle closing and force close (sigkill) of applications.

Fixes: https://github.com/ubports/ubuntu-touch/issues/1184