### PR TITLE
Allow to be built without content-hub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
 add_custom_target(cppcheck COMMAND cppcheck --enable=all -q --error-exitcode=2
                                        ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
 
+option(WITH_CONTENTHUB "Build with content-hub" OFF)
+
 include(FindPkgConfig)
 find_package(Qt5Core 5.4 REQUIRED)
 find_package(Qt5DBus 5.4 REQUIRED)
@@ -91,8 +93,12 @@ pkg_check_modules(GSETTINGS_QT REQUIRED gsettings-qt)
 pkg_check_modules(QTDBUSTEST libqtdbustest-1 REQUIRED)
 pkg_check_modules(QTDBUSMOCK libqtdbusmock-1 REQUIRED)
 pkg_check_modules(APPLICATION_API REQUIRED unity-shell-application=27)
-pkg_check_modules(CONTENT_HUB libcontent-hub>=0.2 REQUIRED)
 pkg_check_modules(VALGRIND valgrind REQUIRED)
+
+if(WITH_CONTENTHUB)
+pkg_check_modules(CONTENT_HUB libcontent-hub>=0.2 REQUIRED)
+message(STATUS "Bulding with content-hub")
+endif()
 
 include_directories(SYSTEM ${APPLICATION_API_INCLUDE_DIRS})
 

--- a/debian/gles-patches/convert-to-gles.patch
+++ b/debian/gles-patches/convert-to-gles.patch
@@ -144,11 +144,11 @@ Index: inline-gles-quilt/debian/rules
  
  override_dh_auto_configure:
 -ifeq ($(DEB_HOST_ARCH),$(USES_GLES2))
- 	mkdir -p $(ANDROID_DIR) && dh_auto_configure -B$(ANDROID_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1
+ 	mkdir -p $(ANDROID_DIR) && dh_auto_configure -B$(ANDROID_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1 -DWITH_CONTENTHUB=ON
 -# See comment in CMakeLists.txt
--	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGL_BUT_LINK_AGAINST_OPENGLES=1
+-	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGL_BUT_LINK_AGAINST_OPENGLES=1 -DWITH_CONTENTHUB=ON
 -else
--	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1
+-	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1 -DWITH_CONTENTHUB=ON
 -endif
  
  override_dh_auto_build:

--- a/debian/rules
+++ b/debian/rules
@@ -28,11 +28,11 @@ endif
 
 override_dh_auto_configure:
 ifeq ($(DEB_HOST_ARCH),$(USES_GLES2))
-	mkdir -p $(ANDROID_DIR) && dh_auto_configure -B$(ANDROID_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1
+	mkdir -p $(ANDROID_DIR) && dh_auto_configure -B$(ANDROID_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1 -DWITH_CONTENTHUB=ON
 # See comment in CMakeLists.txt
-	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGL_BUT_LINK_AGAINST_OPENGLES=1
+	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGL_BUT_LINK_AGAINST_OPENGLES=1 -DWITH_CONTENTHUB=ON
 else
-	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1
+	mkdir -p $(DESKTOP_DIR) && dh_auto_configure -B$(DESKTOP_DIR) -- $(FLAGS) $(CURDIR) -DUSE_OPENGLES=1 -DWITH_CONTENTHUB=ON
 endif
 
 override_dh_auto_build:

--- a/src/platforms/mirserver/CMakeLists.txt
+++ b/src/platforms/mirserver/CMakeLists.txt
@@ -12,6 +12,10 @@ if (QGL_DEBUG)
     add_definitions(-DQGL_DEBUG)
 endif()
 
+if (WITH_CONTENTHUB)
+    add_definitions(-DWITH_CONTENTHUB)
+endif()
+
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -fPIC")
 
 if(Qt5Core_VERSION VERSION_LESS "5.8.0")
@@ -57,7 +61,9 @@ endif()
 
     ${APPLICATION_API_INCLUDE_DIRS}
 
+if(WITH_CONTENTHUB)
     ${CONTENT_HUB_INCLUDE_DIRS}
+endif()
 
     ${VALGRIND_INCLUDE_DIRS}
 )
@@ -84,9 +90,13 @@ set(MIRSERVER_DEPENDANTS
     setqtcompositor.cpp
     )
 
+if(WITH_CONTENTHUB)
+    set(CLIPBOARD_SRC clipboard.cpp)
+endif()
+
 add_library(qpa-mirserver SHARED
     ${MIRSERVER_DEPENDANTS}
-    clipboard.cpp
+    ${CLIPBOARD_SRC}
     cursor.cpp
     initialsurfacesizes.cpp
     inputdeviceobserver.cpp

--- a/src/platforms/mirserver/mirserverintegration.cpp
+++ b/src/platforms/mirserver/mirserverintegration.cpp
@@ -199,6 +199,7 @@ QPlatformNativeInterface *MirServerIntegration::nativeInterface() const
     return m_nativeInterface;
 }
 
+#ifdef WITH_CONTENTHUB
 QPlatformClipboard *MirServerIntegration::clipboard() const
 {
     static QPlatformClipboard *clipboard = nullptr;
@@ -207,6 +208,7 @@ QPlatformClipboard *MirServerIntegration::clipboard() const
     }
     return clipboard;
 }
+#endif
 
 QPlatformOffscreenSurface *MirServerIntegration::createPlatformOffscreenSurface(
         QOffscreenSurface *surface) const

--- a/src/platforms/mirserver/mirserverintegration.h
+++ b/src/platforms/mirserver/mirserverintegration.h
@@ -39,7 +39,9 @@ public:
     QAbstractEventDispatcher *createEventDispatcher() const override;
     void initialize() override;
 
+#ifdef WITH_CONTENTHUB
     QPlatformClipboard *clipboard() const override;
+#endif
 
     QPlatformInputContext* inputContext() const override { return m_inputContext; }
 


### PR DESCRIPTION
As wayland clients do not support nor will it ever support content-hub's
clipboard. Add a option to disable content-hub.

This should be replaced with mirs clipboard implementation once thats
implemented to properly support wayland clipboard.