### PR TITLE
Use MirAL events to trigger our internal screen logic

### DIFF
--- a/src/platforms/mirserver/qmirserver_p.cpp
+++ b/src/platforms/mirserver/qmirserver_p.cpp
@@ -134,7 +134,7 @@ void QMirServerPrivate::run(const std::function<void()> &startCallback)
             m_openGLContextFactory,
             m_mirServerHooks,
             miral::set_window_management_policy<WindowManagementPolicy>(m_windowModelNotifier, m_windowController,
-                    m_appNotifier),
+                    m_appNotifier, screensModel),
             addInitCallback,
             qtmir::SetQtCompositor{screensModel},
             setTerminator,

--- a/src/platforms/mirserver/screensmodel.cpp
+++ b/src/platforms/mirserver/screensmodel.cpp
@@ -122,6 +122,7 @@ void ScreensModel::update()
 
                     // Can we re-use the existing Screen?
                     if (canUpdateExistingScreen(screen, output)) {
+                        qCDebug(QTMIR_SCREENS) << "Can reuse Screen with id" << output.id.as_value();
                         screen->setMirDisplayConfiguration(output);
                         oldScreenList.removeAll(screen);
                         m_screenList.append(screen);
@@ -146,6 +147,8 @@ void ScreensModel::update()
                                            << "and geometry" << screen->geometry();
                     m_screenList.append(screen);
                 }
+            } else {
+                qCDebug(QTMIR_SCREENS) << "Output with ID" << output.id.as_value() << "is not used and connected.";
             }
         }
     );

--- a/src/platforms/mirserver/windowmanagementpolicy.cpp
+++ b/src/platforms/mirserver/windowmanagementpolicy.cpp
@@ -38,10 +38,12 @@ using namespace qtmir;
 WindowManagementPolicy::WindowManagementPolicy(const miral::WindowManagerTools &tools,
                                                qtmir::WindowModelNotifier &windowModel,
                                                qtmir::WindowController &windowController,
-                                               qtmir::AppNotifier &appNotifier)
+                                               qtmir::AppNotifier &appNotifier,
+                                               const QSharedPointer<ScreensModel> screensModel)
     : CanonicalWindowManagerPolicy(tools)
     , m_windowModel(windowModel)
     , m_appNotifier(appNotifier)
+    , m_screensModel(screensModel)
 {
     qRegisterMetaType<qtmir::NewWindow>();
     qRegisterMetaType<std::vector<miral::Window>>();
@@ -215,6 +217,25 @@ void WindowManagementPolicy::advise_begin()
 void WindowManagementPolicy::advise_end()
 {
     Q_EMIT m_windowModel.modificationsEnded();
+}
+
+void WindowManagementPolicy::advise_output_create(miral::Output const& output)
+{
+    Q_UNUSED(output);
+    m_screensModel->update();
+}
+
+void WindowManagementPolicy::advise_output_update(miral::Output const& updated, miral::Output const& original)
+{
+    Q_UNUSED(updated);
+    Q_UNUSED(original);
+    m_screensModel->update();
+}
+
+void WindowManagementPolicy::advise_output_delete(miral::Output const& output)
+{
+    Q_UNUSED(output);
+    m_screensModel->update();
 }
 
 void WindowManagementPolicy::ensureWindowIsActive(const miral::Window &window)

--- a/src/platforms/mirserver/windowmanagementpolicy.h
+++ b/src/platforms/mirserver/windowmanagementpolicy.h
@@ -23,6 +23,7 @@
 #include "qteventfeeder.h"
 #include "windowcontroller.h"
 #include "windowmodelnotifier.h"
+#include "screensmodel.h"
 
 #include <QScopedPointer>
 
@@ -34,7 +35,8 @@ public:
     WindowManagementPolicy(const miral::WindowManagerTools &tools,
                            qtmir::WindowModelNotifier &windowModel,
                            qtmir::WindowController &windowController,
-                           qtmir::AppNotifier &appNotifier);
+                           qtmir::AppNotifier &appNotifier,
+                           const QSharedPointer<ScreensModel> screensModel);
 
     // From WindowManagementPolicy
     auto place_new_window(const miral::ApplicationInfo &app_info,
@@ -71,6 +73,10 @@ public:
     void advise_delete_window(const miral::WindowInfo &windowInfo) override;
     void advise_raise(const std::vector<miral::Window> &windows) override;
 
+    void advise_output_create(miral::Output const& output) override;
+    void advise_output_update(miral::Output const& updated, miral::Output const& original) override;
+    void advise_output_delete(miral::Output const& output) override;
+
     void handle_request_drag_and_drop(miral::WindowInfo &window_info) override;
     void handle_request_move(miral::WindowInfo &window_info, const MirInputEvent *input_event) override;
     void handle_request_resize(miral::WindowInfo &window_info, const MirInputEvent *input_event, MirResizeEdge edge) override;
@@ -101,6 +107,7 @@ private:
 
     qtmir::WindowModelNotifier &m_windowModel;
     qtmir::AppNotifier &m_appNotifier;
+    const QSharedPointer<ScreensModel> m_screensModel;
     QtEventFeeder m_eventFeeder;
     QVector<QRect> m_confinementRegions;
     QMargins m_windowMargins[mir_window_types];


### PR DESCRIPTION
This change adds ScreensModel as a member of our WindowManagementPolicy only so the 'advise_output*' events are used to call ScreensModel::update().

While it would be more correct to use all of MirAL's events to determine our final screen state more programmatically, our existing logic works well if it's triggered correctly.

To aid future debuggers, also add some more debugging output from ScreensModel::update().

~~Replaces~~ Alternative to https://github.com/ubports/qtmir/pull/37 for now.
Should be merged with or after https://github.com/ubports/ubuntu-ui-toolkit/pull/76 to prevent major crashing.
Finally, finally... Fixes https://github.com/ubports/ubuntu-touch/issues/1094