### PR TITLE
[MirSurfaceItem] Ignore hover move events with no timestamp

### DIFF
--- a/src/modules/Unity/Application/mirsurfaceitem.cpp
+++ b/src/modules/Unity/Application/mirsurfaceitem.cpp
@@ -335,7 +335,10 @@ void MirSurfaceItem::hoverLeaveEvent(QHoverEvent *event)
 
 void MirSurfaceItem::hoverMoveEvent(QHoverEvent *event)
 {
-    if (m_consumesInput && m_surface && m_surface->live()) {
+    // WORKAROUND for https://github.com/ubports/ubuntu-touch/issues/787
+    // This is a improved workaround that allows "mouse" hover events to work correctly by
+    // ignoring hover move events with no timestamp as these are bogus synthesized touch events
+    if (m_consumesInput && m_surface && m_surface->live() && event->timestamp() != 0) {
         m_surface->hoverMoveEvent(event);
     } else {
         event->ignore();

--- a/src/modules/Unity/Application/mirsurfaceitem.cpp
+++ b/src/modules/Unity/Application/mirsurfaceitem.cpp
@@ -335,11 +335,6 @@ void MirSurfaceItem::hoverLeaveEvent(QHoverEvent *event)
 
 void MirSurfaceItem::hoverMoveEvent(QHoverEvent *event)
 {
-    // HACK! Ignore hover move events
-    // This is a masive hack and is only done as a temp fix
-    event->ignore();
-    return;
-
     if (m_consumesInput && m_surface && m_surface->live()) {
         m_surface->hoverMoveEvent(event);
     } else {


### PR DESCRIPTION
This is a improved workaround that allows "mouse" hover events to work correctly by ignoring hover move events with no timestamp as these are bogus synthesized touch events. 

This is not *pretty* but its way better then our current hack. 

see https://github.com/ubports/ubuntu-touch/issues/787